### PR TITLE
解决 boost: "cxx11" is not a recognized standard ERROR

### DIFF
--- a/scripts/boost.rb
+++ b/scripts/boost.rb
@@ -1,0 +1,130 @@
+class Boost < Formula
+  desc "Collection of portable C++ source libraries"
+  homepage "https://www.boost.org/"
+  revision 1
+  head "https://github.com/boostorg/boost.git"
+
+  stable do
+    url "https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.bz2"
+    sha256 "2684c972994ee57fc5632e03bf044746f6eb45d4920c343937a465fd67a5adba"
+
+    # Remove for > 1.67.0
+    # Fix "error: no member named 'next' in namespace 'boost'"
+    # Upstream commit from 1 Dec 2017 "Add #include <boost/next_prior.hpp>; no
+    # longer in utility.hpp"
+    patch :p2 do
+      url "https://github.com/boostorg/lockfree/commit/12726cd.patch?full_index=1"
+      sha256 "f165823d961a588b622b20520668b08819eb5fdc08be7894c06edce78026ce0a"
+    end
+  end
+
+  bottle do
+    cellar :any
+    sha256 "265ab8beaa6fa26a7c305ef2e6aec8bd26ca1db105aca0aaca028f32c5245a90" => :high_sierra
+    sha256 "567f3e9a294413c1701b698d666a521cfdeec846e256c6e66576d5b70eb26f08" => :sierra
+    sha256 "3f3f687a620f656fe2ac54f01306e00e6bbc0e9797db284a8d272648d427e640" => :el_capitan
+  end
+
+  option "with-icu4c", "Build regexp engine with icu support"
+  option "without-single", "Disable building single-threading variant"
+  option "without-static", "Disable building static library variant"
+
+  deprecated_option "with-icu" => "with-icu4c"
+
+  depends_on "icu4c" => :optional
+
+  def install
+    # Force boost to compile with the desired compiler
+    open("user-config.jam", "a") do |file|
+      file.write "using darwin : : #{ENV.cxx} ;\n"
+    end
+
+    # libdir should be set by --prefix but isn't
+    bootstrap_args = ["--prefix=#{prefix}", "--libdir=#{lib}"]
+
+    if build.with? "icu4c"
+      icu4c_prefix = Formula["icu4c"].opt_prefix
+      bootstrap_args << "--with-icu=#{icu4c_prefix}"
+    else
+      bootstrap_args << "--without-icu"
+    end
+
+    # Handle libraries that will not be built.
+    without_libraries = ["python", "mpi"]
+
+    # Boost.Log cannot be built using Apple GCC at the moment. Disabled
+    # on such systems.
+    without_libraries << "log" if ENV.compiler == :gcc
+
+    bootstrap_args << "--without-libraries=#{without_libraries.join(",")}"
+
+    # layout should be synchronized with boost-python and boost-mpi
+    args = ["--prefix=#{prefix}",
+            "--libdir=#{lib}",
+            "-d2",
+            "-j#{ENV.make_jobs}",
+            "--layout=tagged",
+            "--user-config=user-config.jam",
+            "-sNO_LZMA=1",
+            "install"]
+
+    if build.with? "single"
+      args << "threading=multi,single"
+    else
+      args << "threading=multi"
+    end
+
+    if build.with? "static"
+      args << "link=shared,static"
+    else
+      args << "link=shared"
+    end
+
+    # Trunk starts using "clang++ -x c" to select C compiler which breaks C++11
+    # handling using ENV.cxx11. Using "cxxflags" and "linkflags" still works.
+    args << "cxxflags=-std=c++11"
+    if ENV.compiler == :clang
+      args << "cxxflags=-stdlib=libc++" << "linkflags=-stdlib=libc++"
+    end
+
+    system "./bootstrap.sh", *bootstrap_args
+    system "./b2", "headers"
+    system "./b2", *args
+  end
+
+  def caveats
+    s = ""
+    # ENV.compiler doesn't exist in caveats. Check library availability
+    # instead.
+    if Dir["#{lib}/libboost_log*"].empty?
+      s += <<~EOS
+        Building of Boost.Log is disabled because it requires newer GCC or Clang.
+      EOS
+    end
+
+    s
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <boost/algorithm/string.hpp>
+      #include <string>
+      #include <vector>
+      #include <assert.h>
+      using namespace boost::algorithm;
+      using namespace std;
+      int main()
+      {
+        string str("a,b");
+        vector<string> strVec;
+        split(strVec, str, is_any_of(","));
+        assert(strVec.size()==2);
+        assert(strVec[0]=="a");
+        assert(strVec[1]=="b");
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "test.cpp", "-std=c++1y", "-L#{lib}", "-lboost_system", "-o", "test"
+    system "./test"
+  end
+end

--- a/scripts/eosio_build_darwin.sh
+++ b/scripts/eosio_build_darwin.sh
@@ -218,7 +218,8 @@
 			done
 		fi
 		printf "\\tInstalling boost libraries.\\n"
-		if ! "${BREW}" install https://raw.githubusercontent.com/Homebrew/homebrew-core/f946d12e295c8a27519b73cc810d06593270a07f/Formula/boost.rb
+		# if ! "${BREW}" install https://raw.githubusercontent.com/Homebrew/homebrew-core/f946d12e295c8a27519b73cc810d06593270a07f/Formula/boost.rb
+		if ! "${BREW}" install "${SOURCE_DIR}/scripts/boost.rb"
 		then
 			printf "\\tUnable to install boost 1.67 libraries at this time. 0\\n"
 			printf "\\tExiting now.\\n\\n"


### PR DESCRIPTION
在MacOS Version: 10.13.6环境下安装EOSForce时，出现了以下 ERROR

boost: "cxx11" is not a recognized standard
Unable to install boost 1.67 libraries at this time. 0 

<img width="575" alt="屏幕快照 2019-04-05 下午5 18 55" src="https://user-images.githubusercontent.com/21288115/55617576-ff4eb480-57c6-11e9-9438-493c1760a0f9.png">

查询资料后参考EOSIO那边的解决方法是，复制一份https://raw.githubusercontent.com/Homebrew/homebrew-core/f946d12e295c8a27519b73cc810d06593270a07f/Formula/boost.rb 文件的代码到eosforce/scripts/boost.rb

并将第36行代码的注释删掉，

#needs :cxx11 -> needs :cxx11 

然后在eosforce/scripts/eosio_build_darwin.sh中替换掉boost的安装路径，将第221行代码替换成

if ! "${BREW}" install "${SOURCE_DIR}/scripts/boost.rb"

问题就解决掉了。

PS：如果这个问题并不重要，请忽略此request ：）
