### PR TITLE
Add Get Vote Reward Http API

### DIFF
--- a/libraries/chain/include/eosio/chain/memory_db.hpp
+++ b/libraries/chain/include/eosio/chain/memory_db.hpp
@@ -102,6 +102,12 @@ public:
       uint64_t primary_key() const { return name; }
    };
 
+   struct assetage {
+      asset     staked        = asset{ 0 };
+      int64_t   age           = 0;
+      uint32_t  update_height = 0;
+   };
+
     struct eoslock_account {
         account_name owner;
         asset     balance;
@@ -113,6 +119,20 @@ public:
       account_name voter;
       asset staked = asset{0};
       uint64_t primary_key() const { return voter; }
+   };
+
+   struct votefix_info {
+      uint64_t     key                = 0;
+      account_name voter              = 0;
+      account_name bpname             = 0;
+      name         fvote_typ          = name{ 0 };
+      assetage     votepower_age;
+      asset        vote               = asset{ 0 };
+      uint32_t     start_block_num    = 0;
+      uint32_t     withdraw_block_num = 0;
+      bool         is_withdraw        = false;
+
+      uint64_t primary_key() const { return key; }
    };
 
    struct bp_info {
@@ -286,3 +306,7 @@ FC_REFLECT(eosio::chain::memory_db::currency_stats, (supply)(max_supply)(issuer)
 FC_REFLECT(eosio::chain::memory_db::vote_info,
            (bpname)(staked)(voteage)(voteage_update_height)(unstaking)(unstake_height))
 FC_REFLECT(eosio::chain::memory_db::vote4ram_info, (voter)(staked))
+FC_REFLECT(eosio::chain::memory_db::assetage, (staked)(age)(update_height))
+FC_REFLECT(eosio::chain::memory_db::votefix_info, 
+               (key)(voter)(bpname)(fvote_typ)(votepower_age)(vote)
+               (start_block_num)(withdraw_block_num)(is_withdraw))

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -105,6 +105,7 @@ void chain_api_plugin::plugin_startup() {
       CHAIN_RO_CALL(get_required_fee, 200),
       CHAIN_RO_CALL(get_chain_configs, 200),
       CHAIN_RO_CALL(get_action_fee, 200),
+      CHAIN_RO_CALL(get_vote_rewards, 200),
       CHAIN_RO_CALL(get_transaction_id, 200),
       CHAIN_RW_CALL_ASYNC(push_block, chain_apis::read_write::push_block_results, 202),
       CHAIN_RW_CALL_ASYNC(push_transaction, chain_apis::read_write::push_transaction_results, 202),

--- a/plugins/chain_plugin/CMakeLists.txt
+++ b/plugins/chain_plugin/CMakeLists.txt
@@ -1,6 +1,7 @@
 file(GLOB HEADERS "include/eosio/chain_plugin/*.hpp")
 add_library( chain_plugin
              chain_plugin.cpp
+             chain_ext_api_imp.cpp
              ${HEADERS} )
 
 target_link_libraries( chain_plugin eosio_chain appbase )

--- a/plugins/chain_plugin/CMakeLists.txt
+++ b/plugins/chain_plugin/CMakeLists.txt
@@ -1,6 +1,7 @@
 file(GLOB HEADERS "include/eosio/chain_plugin/*.hpp")
 add_library( chain_plugin
              chain_plugin.cpp
+             chain_api_helper.cpp
              chain_ext_api_imp.cpp
              ${HEADERS} )
 

--- a/plugins/chain_plugin/chain_api_helper.cpp
+++ b/plugins/chain_plugin/chain_api_helper.cpp
@@ -1,0 +1,73 @@
+#include <eosio/chain_plugin/chain_plugin.hpp>
+#include <eosio/chain/fork_database.hpp>
+#include <eosio/chain/block_log.hpp>
+#include <eosio/chain/exceptions.hpp>
+#include <eosio/chain/authorization_manager.hpp>
+#include <eosio/chain/txfee_manager.hpp>
+#include <eosio/chain/producer_object.hpp>
+#include <eosio/chain/config.hpp>
+#include <eosio/chain/wasm_interface.hpp>
+#include <eosio/chain/resource_limits.hpp>
+#include <eosio/chain/reversible_block_object.hpp>
+#include <eosio/chain/controller.hpp>
+#include <eosio/chain/generated_transaction_object.hpp>
+#include <eosio/chain/snapshot.hpp>
+
+#include <eosio/chain/eosio_contract.hpp>
+#include <eosio/chain/config_on_chain.hpp>
+#include <eosio/chain/memory_db.hpp>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/lexical_cast.hpp>
+
+#include <fc/io/fstream.hpp>
+#include <fc/io/json.hpp>
+#include <fc/variant.hpp>
+
+using namespace eosio;
+using namespace eosio::chain;
+using namespace eosio::chain::config;
+using namespace eosio::chain::plugin_interface;
+using vm_type = wasm_interface::vm_type;
+using fc::flat_map;
+
+namespace eosio {
+namespace chain_apis {
+
+std::vector<fc::variant> read_only::get_table_rows_by_primary_to_json( const name& code,
+                                                                       const uint64_t& scope,
+                                                                       const name& table,
+                                                                       const abi_serializer& abis,
+                                                                       const std::size_t max_size ) const {
+   std::vector<fc::variant> result;
+
+   const auto& d = db.db();
+
+   const auto* t_id = d.find<chain::table_id_object, chain::by_code_scope_table>(boost::make_tuple(code, scope, table));
+   if( t_id != nullptr ) {
+      const auto &idx = d.get_index<key_value_index, by_scope_primary>();
+      result.reserve(max_size);
+
+      decltype(t_id->id) next_tid(t_id->id._id + 1);
+      const auto lower = idx.lower_bound(boost::make_tuple(t_id->id));
+      const auto upper = idx.lower_bound(boost::make_tuple(next_tid));
+
+      std::size_t added = 0;
+      vector<char> data;
+      data.reserve(4096);
+      for( auto itr = lower; itr != upper; ++itr ) {
+         if(added >= max_size) {
+            break;
+         }
+         copy_inline_row(*itr, data);
+         result.push_back(abis.binary_to_variant(abis.get_table_type(table), data, abi_serializer_max_time, shorten_abi_errors));
+         added++;
+      }
+   }
+
+   return result;
+}
+
+
+} // namespace chain_apis
+} // namespace eosio

--- a/plugins/chain_plugin/chain_ext_api_imp.cpp
+++ b/plugins/chain_plugin/chain_ext_api_imp.cpp
@@ -1,0 +1,41 @@
+#include <eosio/chain_plugin/chain_plugin.hpp>
+#include <eosio/chain/fork_database.hpp>
+#include <eosio/chain/block_log.hpp>
+#include <eosio/chain/exceptions.hpp>
+#include <eosio/chain/authorization_manager.hpp>
+#include <eosio/chain/txfee_manager.hpp>
+#include <eosio/chain/producer_object.hpp>
+#include <eosio/chain/config.hpp>
+#include <eosio/chain/wasm_interface.hpp>
+#include <eosio/chain/resource_limits.hpp>
+#include <eosio/chain/reversible_block_object.hpp>
+#include <eosio/chain/controller.hpp>
+#include <eosio/chain/generated_transaction_object.hpp>
+#include <eosio/chain/snapshot.hpp>
+
+#include <eosio/chain/eosio_contract.hpp>
+#include <eosio/chain/config_on_chain.hpp>
+#include <eosio/chain/memory_db.hpp>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/lexical_cast.hpp>
+
+#include <fc/io/fstream.hpp>
+#include <fc/io/json.hpp>
+#include <fc/variant.hpp>
+
+namespace eosio {
+namespace chain_apis {
+
+// get_vote_rewards get voter 's reward by vote in eosforce
+read_only::get_vote_rewards_result read_only::get_vote_rewards( const read_only::get_vote_rewards_params& p )const {
+   read_only::get_vote_rewards_result result;
+
+   ilog( "get_vote_rewards ${acc} from ${bp} in ${num}, ${json}", 
+         ("acc", p.voter)("bp", p.bp_name)("json", p.json)("num", p.block_num) );
+
+   return result;
+}
+
+} // namespace chain_apis
+} // namespace eosio

--- a/plugins/chain_plugin/chain_ext_api_imp.cpp
+++ b/plugins/chain_plugin/chain_ext_api_imp.cpp
@@ -16,6 +16,7 @@
 #include <eosio/chain/eosio_contract.hpp>
 #include <eosio/chain/config_on_chain.hpp>
 #include <eosio/chain/memory_db.hpp>
+#include <eosio/chain/types.hpp>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
@@ -24,17 +25,67 @@
 #include <fc/io/json.hpp>
 #include <fc/variant.hpp>
 
+using eosio::chain::int128_t;
+
 namespace eosio {
 namespace chain_apis {
 
+const auto sys_account = chain::config::system_account_name;
+
 // get_vote_rewards get voter 's reward by vote in eosforce
 read_only::get_vote_rewards_result read_only::get_vote_rewards( const read_only::get_vote_rewards_params& p )const {
-   read_only::get_vote_rewards_result result;
-
    ilog( "get_vote_rewards ${acc} from ${bp} in ${num}, ${json}", 
          ("acc", p.voter)("bp", p.bp_name)("json", p.json)("num", p.block_num) );
 
-   return result;
+   const auto curr_block_num = db.head_block_num();
+
+   // 1. Need BP total voteage and reward_pool info
+   chain::memory_db::bp_info bp_data;
+   EOS_ASSERT( get_table_row_by_primary_key( sys_account, sys_account, N(bps), p.bp_name, bp_data ), 
+               chain::contract_table_query_exception,
+               "cannot find bp info by name ${n}", ("n", p.bp_name) );
+
+   ilog( "bp data: ${data}", ("data", bp_data) );
+
+   const auto bp_total_assetage = 
+        ( static_cast<int128_t>(bp_data.total_staked)
+          * static_cast<int128_t>(curr_block_num - bp_data.voteage_update_height) )
+      + bp_data.total_voteage;
+
+   ilog( "bp data: ${data} on ${n}", ("data", bp_total_assetage)("n", curr_block_num) );
+
+   uint64_t voter_total_assetage = 0;
+
+   // 2. Need calc voter current vote voteage
+   chain::memory_db::vote_info curr_vote_data;
+   const auto is_has_curr_vote = get_table_row_by_primary_key(
+         sys_account, p.voter, N(votes), p.bp_name, curr_vote_data );
+   if( is_has_curr_vote ) {
+      ilog( "get current vote data : ${d}", ("d", curr_vote_data) );
+      const auto curr_vote_assetage = 
+         (   static_cast<int128_t>(curr_vote_data.staked.get_amount() / curr_vote_data.staked.precision()) 
+           * static_cast<int128_t>(curr_block_num - curr_vote_data.voteage_update_height) )
+         + curr_vote_data.voteage;
+      
+      ilog( "get current vote assetage : ${d}", ("d", curr_vote_assetage) );
+      voter_total_assetage += curr_vote_assetage;
+   }
+
+   // 3. Need calc the sum of voter 's fix-time vote voteage
+
+   // 4. Make reward to result
+   const auto amount_voteage = static_cast<int128_t>( bp_data.rewards_pool.get_amount() ) 
+                             * voter_total_assetage;
+   const auto& reward = asset{
+      static_cast<int64_t>( amount_voteage / bp_total_assetage )
+   };
+
+   return {
+      reward,
+      voter_total_assetage,
+      curr_block_num,
+      {}
+   };
 }
 
 } // namespace chain_apis

--- a/plugins/chain_plugin/chain_ext_api_imp.cpp
+++ b/plugins/chain_plugin/chain_ext_api_imp.cpp
@@ -72,6 +72,17 @@ read_only::get_vote_rewards_result read_only::get_vote_rewards( const read_only:
    }
 
    // 3. Need calc the sum of voter 's fix-time vote voteage
+   walk_table_by_seckey<chain::memory_db::votefix_info>( 
+      sys_account, p.voter, N(fixvotes), p.bp_name, 
+      [&]( unsigned int c, const chain::memory_db::votefix_info& v ) -> bool{
+         ilog("walk fix ${n} : ${data}", ("n", c)("data", v));
+         const auto fix_votepower_age =
+            (   static_cast<int128_t>(v.votepower_age.staked.get_amount() / v.votepower_age.staked.precision())
+              * static_cast<int128_t>(curr_block_num - v.votepower_age.update_height) )
+            + v.votepower_age.age;
+         voter_total_assetage += fix_votepower_age;
+         return false; // no break
+   } );
 
    // 4. Make reward to result
    const auto amount_voteage = static_cast<int128_t>( bp_data.rewards_pool.get_amount() ) 

--- a/plugins/chain_plugin/chain_ext_api_imp.cpp
+++ b/plugins/chain_plugin/chain_ext_api_imp.cpp
@@ -88,7 +88,9 @@ read_only::get_vote_rewards_result read_only::get_vote_rewards( const read_only:
    const auto amount_voteage = static_cast<int128_t>( bp_data.rewards_pool.get_amount() ) 
                              * voter_total_assetage;
    const auto& reward = asset{
-      static_cast<int64_t>( amount_voteage / bp_total_assetage )
+      bp_total_assetage > 0
+            ? static_cast<int64_t>( amount_voteage / bp_total_assetage )
+            : 0
    };
 
    return {

--- a/plugins/chain_plugin/chain_ext_api_imp.cpp
+++ b/plugins/chain_plugin/chain_ext_api_imp.cpp
@@ -34,8 +34,8 @@ const auto sys_account = chain::config::system_account_name;
 
 // get_vote_rewards get voter 's reward by vote in eosforce
 read_only::get_vote_rewards_result read_only::get_vote_rewards( const read_only::get_vote_rewards_params& p )const {
-   ilog( "get_vote_rewards ${acc} from ${bp} in ${num}, ${json}", 
-         ("acc", p.voter)("bp", p.bp_name)("json", p.json)("num", p.block_num) );
+   ilog( "get_vote_rewards ${acc} from ${bp}", 
+         ("acc", p.voter)("bp", p.bp_name));
 
    const auto curr_block_num = db.head_block_num();
 

--- a/plugins/chain_plugin/chain_ext_api_imp.cpp
+++ b/plugins/chain_plugin/chain_ext_api_imp.cpp
@@ -34,8 +34,7 @@ const auto sys_account = chain::config::system_account_name;
 
 // get_vote_rewards get voter 's reward by vote in eosforce
 read_only::get_vote_rewards_result read_only::get_vote_rewards( const read_only::get_vote_rewards_params& p )const {
-   ilog( "get_vote_rewards ${acc} from ${bp}", 
-         ("acc", p.voter)("bp", p.bp_name));
+   //ilog( "get_vote_rewards ${acc} from ${bp}", ("acc", p.voter)("bp", p.bp_name));
 
    const auto curr_block_num = db.head_block_num();
 
@@ -45,14 +44,14 @@ read_only::get_vote_rewards_result read_only::get_vote_rewards( const read_only:
                chain::contract_table_query_exception,
                "cannot find bp info by name ${n}", ("n", p.bp_name) );
 
-   ilog( "bp data: ${data}", ("data", bp_data) );
+   //ilog( "bp data: ${data}", ("data", bp_data) );
 
    const auto bp_total_assetage = 
         ( static_cast<int128_t>(bp_data.total_staked)
           * static_cast<int128_t>(curr_block_num - bp_data.voteage_update_height) )
       + bp_data.total_voteage;
 
-   ilog( "bp data: ${data} on ${n}", ("data", bp_total_assetage)("n", curr_block_num) );
+   //ilog( "bp data: ${data} on ${n}", ("data", bp_total_assetage)("n", curr_block_num) );
 
    uint64_t voter_total_assetage = 0;
 
@@ -61,13 +60,13 @@ read_only::get_vote_rewards_result read_only::get_vote_rewards( const read_only:
    const auto is_has_curr_vote = get_table_row_by_primary_key(
          sys_account, p.voter, N(votes), p.bp_name, curr_vote_data );
    if( is_has_curr_vote ) {
-      ilog( "get current vote data : ${d}", ("d", curr_vote_data) );
+      //ilog( "get current vote data : ${d}", ("d", curr_vote_data) );
       const auto curr_vote_assetage = 
          (   static_cast<int128_t>(curr_vote_data.staked.get_amount() / curr_vote_data.staked.precision()) 
            * static_cast<int128_t>(curr_block_num - curr_vote_data.voteage_update_height) )
          + curr_vote_data.voteage;
       
-      ilog( "get current vote assetage : ${d}", ("d", curr_vote_assetage) );
+      //ilog( "get current vote assetage : ${d}", ("d", curr_vote_assetage) );
       voter_total_assetage += curr_vote_assetage;
    }
 
@@ -75,7 +74,7 @@ read_only::get_vote_rewards_result read_only::get_vote_rewards( const read_only:
    walk_table_by_seckey<chain::memory_db::votefix_info>( 
       sys_account, p.voter, N(fixvotes), p.bp_name, 
       [&]( unsigned int c, const chain::memory_db::votefix_info& v ) -> bool{
-         ilog("walk fix ${n} : ${data}", ("n", c)("data", v));
+         //ilog("walk fix ${n} : ${data}", ("n", c)("data", v));
          const auto fix_votepower_age =
             (   static_cast<int128_t>(v.votepower_age.staked.get_amount() / v.votepower_age.staked.precision())
               * static_cast<int128_t>(curr_block_num - v.votepower_age.update_height) )

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1925,40 +1925,6 @@ read_only::get_action_fee_result read_only::get_action_fee( const get_action_fee
    return get_action_fee_result{db.get_txfee_manager().get_required_fee(db, params.account, params.action)};
 }
 
-std::vector<fc::variant> read_only::get_table_rows_by_primary_to_json( const name& code,
-                                                                       const uint64_t& scope,
-                                                                       const name& table,
-                                                                       const abi_serializer& abis,
-                                                                       const std::size_t max_size ) const {
-   std::vector<fc::variant> result;
-
-   const auto& d = db.db();
-
-   const auto* t_id = d.find<chain::table_id_object, chain::by_code_scope_table>(boost::make_tuple(code, scope, table));
-   if( t_id != nullptr ) {
-      const auto &idx = d.get_index<key_value_index, by_scope_primary>();
-      result.reserve(max_size);
-
-      decltype(t_id->id) next_tid(t_id->id._id + 1);
-      const auto lower = idx.lower_bound(boost::make_tuple(t_id->id));
-      const auto upper = idx.lower_bound(boost::make_tuple(next_tid));
-
-      std::size_t added = 0;
-      vector<char> data;
-      data.reserve(4096);
-      for( auto itr = lower; itr != upper; ++itr ) {
-         if(added >= max_size) {
-            break;
-         }
-         copy_inline_row(*itr, data);
-         result.push_back(abis.binary_to_variant(abis.get_table_type(table), data, abi_serializer_max_time, shorten_abi_errors));
-         added++;
-      }
-   }
-
-   return result;
-}
-
 read_only::get_transaction_id_result read_only::get_transaction_id( const read_only::get_transaction_id_params& params)const {
    return params.id();
 }

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -213,6 +213,7 @@ public:
    get_raw_code_and_abi_results get_raw_code_and_abi( const get_raw_code_and_abi_params& params)const;
    get_raw_abi_results get_raw_abi( const get_raw_abi_params& params)const;
 
+   // some helper funcs for get data from table in chain
    std::vector<fc::variant> get_table_rows_by_primary_to_json( const name& code,
                                                                const uint64_t& scope,
                                                                const name& table, 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -382,6 +382,22 @@ public:
 
    get_producers_result get_producers( const get_producers_params& params )const;
 
+   struct get_vote_rewards_params {
+      bool         json      = false;
+      account_name voter     = 0;
+      account_name bp_name   = 0;
+      uint32_t     block_num = 0;
+   };
+
+   struct get_vote_rewards_result {
+      asset     vote_reward;
+      uint128_t vote_assetage_sum = 0;
+      uint32_t  block_num         = 0;
+      vector<fc::variant> ext_datas;
+   };
+
+   get_vote_rewards_result get_vote_rewards( const get_vote_rewards_params& params )const;
+
    struct get_producer_schedule_params {
    };
 
@@ -810,3 +826,5 @@ FC_REFLECT( eosio::chain_apis::read_only::get_chain_configs_params, (typ) )
 FC_REFLECT( eosio::chain_apis::read_only::get_chain_configs_result, (typ)(num)(key)(fee) )
 FC_REFLECT( eosio::chain_apis::read_only::get_action_fee_params, (account)(action) )
 FC_REFLECT( eosio::chain_apis::read_only::get_action_fee_result, (fee) )
+FC_REFLECT( eosio::chain_apis::read_only::get_vote_rewards_params, (json)(voter)(bp_name)(block_num) )
+FC_REFLECT( eosio::chain_apis::read_only::get_vote_rewards_result, (vote_reward)(vote_assetage_sum)(block_num)(ext_datas) )

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -408,10 +408,8 @@ public:
    get_producers_result get_producers( const get_producers_params& params )const;
 
    struct get_vote_rewards_params {
-      bool         json      = false;
       account_name voter     = 0;
       account_name bp_name   = 0;
-      uint32_t     block_num = 0;
    };
 
    struct get_vote_rewards_result {
@@ -851,5 +849,5 @@ FC_REFLECT( eosio::chain_apis::read_only::get_chain_configs_params, (typ) )
 FC_REFLECT( eosio::chain_apis::read_only::get_chain_configs_result, (typ)(num)(key)(fee) )
 FC_REFLECT( eosio::chain_apis::read_only::get_action_fee_params, (account)(action) )
 FC_REFLECT( eosio::chain_apis::read_only::get_action_fee_result, (fee) )
-FC_REFLECT( eosio::chain_apis::read_only::get_vote_rewards_params, (json)(voter)(bp_name)(block_num) )
+FC_REFLECT( eosio::chain_apis::read_only::get_vote_rewards_params, (voter)(bp_name) )
 FC_REFLECT( eosio::chain_apis::read_only::get_vote_rewards_result, (vote_reward)(vote_assetage_sum)(block_num)(ext_datas) )


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

In EOSForce, to get account 's vote reward is need a complex calc,
now this PR add a http api to get vote reward for account by vote to a bp.

Note account 's reward may increase every block, so this API will return which block num to this reward.

To calc the vote reward may need a lot of datas, so this request will failed if it cost to much times, it will happen when a account to make too much fix-time votes. 

## Consensus Changes
- [ ] Consensus Changes
<!-- checked [x] = Consensus changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the validation of blocks in the chain or consensus in general, please describe the impact. -->


## API Changes
- [x] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->

This PR add /v1/chain/get_vote_rewards api:

```bash
curl --request POST \
  --url http://127.0.0.1:8001/v1/chain/get_vote_rewards \
  --header 'accept: application/json' \
  --header 'content-type: application/json' \
  --data '{ "voter":"testf","bp_name":"biosbpe" }'
```

## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
